### PR TITLE
Fixed error message in CHOICE

### DIFF
--- a/start_server.cmd
+++ b/start_server.cmd
@@ -505,7 +505,7 @@ if /I "%ENABLEUPNP%"=="y" call :setupnp
 
 echo Would you like to validate or update the server files? 'Y' recommended.
 echo   ^( auto-validation will commence in 10 seconds ^)
-CHOICE /d Y /T 10 /M "Validate and/or update the server?"
+CHOICE /C YNQ /d Y /T 10 /M "Validate and/or update the server?"
 IF !ERRORLEVEL! EQU 1 call :validateserver
 
 call :cleanmods
@@ -513,7 +513,7 @@ call :printconfig
 call :startserver
 echo.
 echo [1m[33mThe Miscreated server exited.[0m
-CHOICE /d Y /T 10 /M "Would you like to restart the server? (auto-restart in 10 seconds)"
+CHOICE /C YNQ /d Y /T 10 /M "Would you like to restart the server? (auto-restart in 10 seconds)"
 IF !ERRORLEVEL! EQU 1 goto start
 
 goto :eof


### PR DESCRIPTION
In other languages then english the choice command have other options. Default in germany is /C a list of JNA (Ja Nein Abbrechen). Changed the script to /C YNQ and runs properly.